### PR TITLE
[PM-7150] Stop harcoding `rk` value sent to the authenticator

### DIFF
--- a/passkey-client/src/tests/mod.rs
+++ b/passkey-client/src/tests/mod.rs
@@ -346,7 +346,7 @@ async fn client_register_triggers_uv_when_uv_is_required() {
     let mut options = webauthn::CredentialCreationOptions {
         public_key: good_credential_creation_options(),
     };
-    options.public_key.authenticator_selection = Some(webauthn::AuthenticatorSelectionCriteria {
+    options.public_key.authenticator_selection = Some(AuthenticatorSelectionCriteria {
         user_verification: webauthn::UserVerificationRequirement::Required,
         authenticator_attachment: Default::default(),
         resident_key: Default::default(),
@@ -373,7 +373,7 @@ async fn client_register_does_not_trigger_uv_when_uv_is_discouraged() {
     let mut options = webauthn::CredentialCreationOptions {
         public_key: good_credential_creation_options(),
     };
-    options.public_key.authenticator_selection = Some(webauthn::AuthenticatorSelectionCriteria {
+    options.public_key.authenticator_selection = Some(AuthenticatorSelectionCriteria {
         user_verification: webauthn::UserVerificationRequirement::Discouraged,
         authenticator_attachment: Default::default(),
         resident_key: Default::default(),

--- a/passkey-types/src/webauthn/attestation.rs
+++ b/passkey-types/src/webauthn/attestation.rs
@@ -322,7 +322,7 @@ impl PublicKeyCredentialParameters {
 /// <https://w3c.github.io/webauthn/#dictdef-authenticatorselectioncriteria>
 ///
 /// [Relying Parties]: https://w3c.github.io/webauthn/#webauthn-relying-party
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[typeshare]
 pub struct AuthenticatorSelectionCriteria {


### PR DESCRIPTION
> UP, UV and RK are currently hardcoded to true in the client, meaning that we will always create discoverable credentials, even if they aren’t actually requested.