### PR TITLE
Export StoreInfo

### DIFF
--- a/passkey-authenticator/src/lib.rs
+++ b/passkey-authenticator/src/lib.rs
@@ -43,7 +43,7 @@ use passkey_types::{ctap2::Ctap2Error, Bytes};
 
 pub use self::{
     authenticator::Authenticator,
-    credential_store::{CredentialStore, DiscoverabilitySupport, MemoryStore},
+    credential_store::{CredentialStore, DiscoverabilitySupport, MemoryStore, StoreInfo},
     ctap2::Ctap2Api,
     u2f::U2fApi,
     user_validation::{UserCheck, UserValidationMethod},


### PR DESCRIPTION
@coroiu Seems like we forgot to export `StoreInfo` which makes it impossible to implement the `CredentialStore` on external crates, so  I've added it to the list of exported items.