### PR TITLE
Expose some functions we use in our SDK

### DIFF
--- a/passkey-authenticator/src/lib.rs
+++ b/passkey-authenticator/src/lib.rs
@@ -54,7 +54,7 @@ pub use self::user_validation::MockUserValidationMethod;
 
 /// Extract a cryptographic secret key from a [`CoseKey`].
 // possible candidate for a `passkey-crypto` crate?
-fn private_key_from_cose_key(key: &CoseKey) -> Result<SecretKey, Ctap2Error> {
+pub fn private_key_from_cose_key(key: &CoseKey) -> Result<SecretKey, Ctap2Error> {
     if !matches!(
         key.alg,
         Some(coset::RegisteredLabelWithPrivate::Assigned(
@@ -143,13 +143,17 @@ pub fn public_key_der_from_cose_key(key: &CoseKey) -> Result<Bytes, Ctap2Error> 
         .map(|pk| pk.as_ref().to_vec().into())
 }
 
-pub(crate) struct CoseKeyPair {
-    public: CoseKey,
-    private: CoseKey,
+/// A COSE key pair, containing both the public and private keys.
+pub struct CoseKeyPair {
+    /// The public key.
+    pub public: CoseKey,
+    /// The private key.
+    pub private: CoseKey,
 }
 
 impl CoseKeyPair {
-    fn from_secret_key(private_key: &SecretKey, algorithm: Algorithm) -> Self {
+    /// Create a new COSE key pair from a secret key and algorithm.
+    pub fn from_secret_key(private_key: &SecretKey, algorithm: Algorithm) -> Self {
         let public_key = SigningKey::from(private_key)
             .verifying_key()
             .to_encoded_point(false);

--- a/passkey-types/src/ctap2/attestation_fmt.rs
+++ b/passkey-types/src/ctap2/attestation_fmt.rs
@@ -252,7 +252,8 @@ impl AttestedCredentialData {
 
 impl AttestedCredentialData {
     /// Custom implementation rather than IntoIterator because the iterator type is complicated.
-    fn into_iter(self) -> impl Iterator<Item = u8> {
+    #[allow(clippy::should_implement_trait)]
+    pub fn into_iter(self) -> impl Iterator<Item = u8> {
         // SAFETY: if this unwrap fails, it is programmer error
         // unfortunately any serialization in Coset does not use serde::Serialize and takes by value ...
         let cose_key = self.key.to_vec().unwrap();


### PR DESCRIPTION
With these changes we avoid having to copy some of the crypto code over to our crates.