### PR TITLE
Remove duplicated options

### DIFF
--- a/passkey-authenticator/src/authenticator/make_credential.rs
+++ b/passkey-authenticator/src/authenticator/make_credential.rs
@@ -128,7 +128,7 @@ where
         //    error.
         let flags = self
             .check_user(
-                UIHint::RequestNewCredential(&input.user.clone().into(), &input.rp, &input.options),
+                UIHint::RequestNewCredential(&input.user.clone().into(), &input.rp),
                 &input.options,
             )
             .await?;
@@ -230,11 +230,7 @@ mod tests {
         let shared_store = Arc::new(Mutex::new(MemoryStore::new()));
         let user_mock = MockUserValidationMethod::verified_user_with_hint(
             1,
-            MockUIHint::RequestNewCredential(
-                request.user.clone().into(),
-                request.rp.clone(),
-                request.options.clone(),
-            ),
+            MockUIHint::RequestNewCredential(request.user.clone().into(), request.rp.clone()),
         );
 
         let mut authenticator =

--- a/passkey-authenticator/src/user_validation.rs
+++ b/passkey-authenticator/src/user_validation.rs
@@ -1,6 +1,5 @@
 use passkey_types::{
     ctap2::{
-        get_assertion::Options,
         make_credential::{PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity},
         Ctap2Error,
     },
@@ -23,7 +22,6 @@ pub enum UIHint<'a, P> {
     RequestNewCredential(
         &'a PublicKeyCredentialUserEntity,
         &'a PublicKeyCredentialRpEntity,
-        &'a Options,
     ),
 
     /// Request permission to use the existing credential in this object.
@@ -89,11 +87,7 @@ pub trait UserValidationMethod {
 pub enum MockUIHint {
     InformExcludedCredentialFound(Passkey),
     InformNoCredentialsFound,
-    RequestNewCredential(
-        PublicKeyCredentialUserEntity,
-        PublicKeyCredentialRpEntity,
-        Options,
-    ),
+    RequestNewCredential(PublicKeyCredentialUserEntity, PublicKeyCredentialRpEntity),
     RequestExistingCredential(Passkey),
 }
 
@@ -150,8 +144,8 @@ impl MockUserValidationMethod {
                         MockUIHint::InformNoCredentialsFound => {
                             matches!(actual_hint, UIHint::InformNoCredentialsFound)
                         }
-                        MockUIHint::RequestNewCredential(user, rp, options) => {
-                            actual_hint == &UIHint::RequestNewCredential(user, rp, options)
+                        MockUIHint::RequestNewCredential(user, rp) => {
+                            actual_hint == &UIHint::RequestNewCredential(user, rp)
                         }
                         MockUIHint::RequestExistingCredential(p) => {
                             actual_hint == &UIHint::RequestExistingCredential(p)


### PR DESCRIPTION
Remove the options value in `UIHint::RequestNewCredential`, which is duplicate as we already pass it to `check_user`. We noticed this a while ago but then forgot to remove it.