### PR TITLE
Make typeshare dependency optional

### DIFF
--- a/passkey-client/Cargo.toml
+++ b/passkey-client/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [features]
 tokio = ["dep:tokio"]
 testable = ["dep:mockall"]
+typeshare = ["passkey-types/typeshare", "dep:typeshare"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -28,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ciborium = "0.2"
 mockall = { version = "0.11", optional = true }
-typeshare = "1"
+typeshare = { version = "1", optional = true }
 idna = "0.5"
 url = "2"
 coset = "0.3"

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -34,13 +34,14 @@ use passkey_types::{
     Passkey,
 };
 use serde::Serialize;
+#[cfg(feature = "typeshare")]
 use typeshare::typeshare;
 use url::Url;
 
 #[cfg(test)]
 mod tests;
 
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 #[derive(Debug, serde::Serialize, PartialEq, Eq)]
 #[serde(tag = "type", content = "content")]
 /// Errors produced by Webauthn Operations.

--- a/passkey-types/Cargo.toml
+++ b/passkey-types/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [features]
 default = []
 serialize_bytes_as_base64_string = []
+typeshare = ["dep:typeshare"]
 
 [dependencies]
 bitflags = "2"
@@ -28,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.10"
 strum = { version = "0.25", features = ["derive"] }
-typeshare = "1"
+typeshare = { version = "1", optional = true }
 # TODO: investigate rolling our own IANA listings and COSE keys
 coset = "0.3"
 

--- a/passkey-types/src/utils/bytes.rs
+++ b/passkey-types/src/utils/bytes.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
+#[cfg(feature = "typeshare")]
 use typeshare::typeshare;
 
 use super::encoding;
@@ -16,7 +17,7 @@ use super::encoding;
 /// This will use an array of numbers for JSON, and a byte string in CBOR for example.
 ///
 /// It also supports deserializing from `base64` and `base64url` formatted strings.
-#[typeshare(transparent)]
+#[cfg_attr(feature = "typeshare", typeshare(transparent))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[repr(transparent)]
 pub struct Bytes(Vec<u8>);

--- a/passkey-types/src/webauthn.rs
+++ b/passkey-types/src/webauthn.rs
@@ -3,6 +3,7 @@
 //! [WebAuthn Level 3]: https://w3c.github.io/webauthn
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "typeshare")]
 use typeshare::typeshare;
 
 use crate::{utils::serde::ignore_unknown, Bytes};
@@ -37,7 +38,7 @@ impl AuthenticatorResponse for AuthenticatorAttestationResponse {}
 /// <https://w3c.github.io/webauthn/#iface-pkcredential>
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct PublicKeyCredential<R: AuthenticatorResponse> {
     /// The id contains the credential ID, chosen by the authenticator. This is usually the base64url
     /// encoded data of [Self::raw_id]

--- a/passkey-types/src/webauthn/assertion.rs
+++ b/passkey-types/src/webauthn/assertion.rs
@@ -1,6 +1,7 @@
 //! Types used for public key authentication
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "typeshare")]
 use typeshare::typeshare;
 
 use crate::{
@@ -22,7 +23,7 @@ use crate::{
 };
 
 /// The response to the successful authentication of a [`PublicKeyCredential`]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub type AuthenticatedPublicKeyCredential = PublicKeyCredential<AuthenticatorAssertionResponse>;
 
 /// This type supplies `get()` requests with the data it needs to generate an assertion.
@@ -31,7 +32,7 @@ pub type AuthenticatedPublicKeyCredential = PublicKeyCredential<AuthenticatorAss
 /// <https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptions>
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct PublicKeyCredentialRequestOptions {
     /// This member specifies a challenge that the authenticator signs, along with other data, when
     /// producing an authentication assertion. See the [Cryptographic Challenges] security consideration.
@@ -168,7 +169,7 @@ pub struct PublicKeyCredentialRequestOptions {
 /// [`navigator.credentials.get`]: https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/get
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct CredentialRequestOptions {
     /// The key defining that this is a request for a webauthn credential.
     pub public_key: PublicKeyCredentialRequestOptions,
@@ -183,7 +184,7 @@ pub struct CredentialRequestOptions {
 /// <https://w3c.github.io/webauthn/#iface-authenticatorassertionresponse>
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct AuthenticatorAssertionResponse {
     /// This attribute contains the JSON serialization of [`CollectedClientData`] passed to the
     /// authenticator by the client in order to generate this credential. The exact JSON serialization

--- a/passkey-types/src/webauthn/attestation.rs
+++ b/passkey-types/src/webauthn/attestation.rs
@@ -3,6 +3,7 @@ use coset::iana;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize, Serializer};
 use std::fmt;
+#[cfg(feature = "typeshare")]
 use typeshare::typeshare;
 
 use crate::{
@@ -24,7 +25,7 @@ use crate::{
 };
 
 /// The response to the successful creation of a PublicKeyCredential
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub type CreatedPublicKeyCredential = PublicKeyCredential<AuthenticatorAttestationResponse>;
 
 /// This is the expected input to [`navigator.credentials.create`] when wanting to create a webauthn
@@ -35,7 +36,7 @@ pub type CreatedPublicKeyCredential = PublicKeyCredential<AuthenticatorAttestati
 /// [`navigator.credentials.create`]: https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct CredentialCreationOptions {
     /// The key defining that this is a request for a webauthn credential.
     pub public_key: PublicKeyCredentialCreationOptions,
@@ -46,7 +47,7 @@ pub struct CredentialCreationOptions {
 /// <https://w3c.github.io/webauthn/#dictdef-publickeycredentialcreationoptions>
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct PublicKeyCredentialCreationOptions {
     /// This member contains a name and an identifier for the [Relying Party] responsible for the request.
     ///
@@ -169,7 +170,7 @@ pub struct PublicKeyCredentialCreationOptions {
 ///
 /// <https://w3c.github.io/webauthn/#dictdef-publickeycredentialrpentity>
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct PublicKeyCredentialRpEntity {
     /// A unique identifier for the [Relying Party] entity, which sets the [RP ID].
     ///
@@ -223,7 +224,7 @@ pub struct PublicKeyCredentialRpEntity {
 /// [Lang]: https://w3c.github.io/webauthn/#sctn-strings-langdir
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct PublicKeyCredentialUserEntity {
     /// The user handle of the user account. A user handle is an opaque byte sequence with a maximum
     /// size of 64 bytes, and is not meant to be displayed to the user.
@@ -274,7 +275,7 @@ pub struct PublicKeyCredentialUserEntity {
 ///
 /// <https://w3c.github.io/webauthn/#dictdef-publickeycredentialparameters>
 #[derive(Debug, Serialize, Deserialize)]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct PublicKeyCredentialParameters {
     /// This member specifies the type of credential to be created. The value SHOULD be a member of
     /// [`PublicKeyCredentialType`] but client platforms MUST ignore unknown values, ignoring any
@@ -282,6 +283,7 @@ pub struct PublicKeyCredentialParameters {
     #[serde(rename = "type", deserialize_with = "ignore_unknown")]
     pub ty: PublicKeyCredentialType,
 
+    #[cfg(feature = "typeshare")]
     /// This member specifies the cryptographic signature algorithm with which the newly generated
     /// credential will be used, and thus also the type of asymmetric key pair to be generated,
     /// e.g., RSA or Elliptic Curve.
@@ -291,6 +293,17 @@ pub struct PublicKeyCredentialParameters {
     /// >       sent over a low-bandwidth link.
     #[serde(with = "i64_to_iana")]
     #[typeshare(serialized_as = "I54")] // because i64 fails for js
+    pub alg: iana::Algorithm,
+
+    #[cfg(not(feature = "typeshare"))]
+    /// This member specifies the cryptographic signature algorithm with which the newly generated
+    /// credential will be used, and thus also the type of asymmetric key pair to be generated,
+    /// e.g., RSA or Elliptic Curve.
+    ///
+    /// > Note: we use `alg` as the latter member name, rather than spelling-out `algorithm`,
+    /// >       because it will be serialized into a message to the authenticator, which may be
+    /// >       sent over a low-bandwidth link.
+    #[serde(with = "i64_to_iana")]
     pub alg: iana::Algorithm,
 }
 
@@ -324,7 +337,7 @@ impl PublicKeyCredentialParameters {
 /// [Relying Parties]: https://w3c.github.io/webauthn/#webauthn-relying-party
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct AuthenticatorSelectionCriteria {
     /// If this member is present, eligible authenticators are filtered to be only those
     /// authenticators attached with the specified [`AuthenticatorAttachment`] modality. If this
@@ -388,7 +401,7 @@ pub struct AuthenticatorSelectionCriteria {
 /// [discoverable credential]: https://w3c.github.io/webauthn/#client-side-discoverable-credential
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-#[typeshare(serialized_as = "String")]
+#[cfg_attr(feature = "typeshare", typeshare(serialized_as = "String"))]
 pub enum ResidentKeyRequirement {
     /// The Relying Party prefers creating a [server-side credential], but will accept a client-side
     /// discoverable credential. The client and authenticator SHOULD create a server-side credential
@@ -425,7 +438,7 @@ pub enum ResidentKeyRequirement {
 /// [attestation conveyance]: https://w3c.github.io/webauthn/#attestation-conveyance
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-#[typeshare(serialized_as = "String")]
+#[cfg_attr(feature = "typeshare", typeshare(serialized_as = "String"))]
 pub enum AttestationConveyancePreference {
     /// The Relying Party is not interested in authenticator attestation. For example, in order to
     /// potentially avoid having to obtain user consent to relay identifying information to the
@@ -474,7 +487,7 @@ pub enum AttestationConveyancePreference {
 /// [2]: https://w3c.github.io/webauthn/#sctn-attstn-fmt-ids
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub enum AttestationStatementFormatIdentifiers {
     /// The `packed` attestation statement format is a WebAuthn-optimized format for attestation.
     /// It uses a very compact but still extensible encoding method. This format is implementable by
@@ -516,7 +529,7 @@ pub enum AttestationStatementFormatIdentifiers {
 /// [Relying Party]: https://w3c.github.io/webauthn/#relying-party
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct AuthenticatorAttestationResponse {
     /// This attribute contains the JSON serialization of [`CollectedClientData`] passed to the
     /// authenticator by the client in order to generate this credential. The exact JSON serialization
@@ -533,10 +546,17 @@ pub struct AuthenticatorAttestationResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_key: Option<Bytes>,
 
+    #[cfg(feature = "typeshare")]
     /// This is the [CoseAlgorithmIdentifier] of the new credential
     ///
     /// [CoseAlgorithmIdentifier]: https://w3c.github.io/webauthn/#typedefdef-cosealgorithmidentifier
     #[typeshare(serialized_as = "I54")] // because i64 fails for js
+    pub public_key_algorithm: i64,
+
+    #[cfg(not(feature = "typeshare"))]
+    /// This is the [CoseAlgorithmIdentifier] of the new credential
+    ///
+    /// [CoseAlgorithmIdentifier]: https://w3c.github.io/webauthn/#typedefdef-cosealgorithmidentifier
     pub public_key_algorithm: i64,
 
     /// This attribute contains an attestation object, which is opaque to, and cryptographically
@@ -626,7 +646,7 @@ where
 
 /// Used to limit the values of [`CollectedClientData::ty`] and serializes to static strings.
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub enum ClientDataType {
     /// Serializes to the string `"webauthn.create"`
     #[serde(rename = "webauthn.create")]

--- a/passkey-types/src/webauthn/common.rs
+++ b/passkey-types/src/webauthn/common.rs
@@ -1,6 +1,7 @@
 //! Common types used in both Attestation (registration) and Assertion (authentication).
 //!
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "typeshare")]
 use typeshare::typeshare;
 
 use crate::{
@@ -22,7 +23,7 @@ use crate::webauthn::{
 /// <https://w3c.github.io/webauthn/#enumdef-publickeycredentialtype>
 #[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-#[typeshare(serialized_as = "String")]
+#[cfg_attr(feature = "typeshare", typeshare(serialized_as = "String"))]
 pub enum PublicKeyCredentialType {
     /// Currently the only type defined is a `PublicKey` meaning the public conterpart of an
     /// asymmetric key pair.
@@ -41,7 +42,7 @@ pub enum PublicKeyCredentialType {
 ///
 /// <https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptor>
 #[derive(Debug, Serialize, Deserialize)]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct PublicKeyCredentialDescriptor {
     /// This member contains the type of the public key credential the caller is referring to. The
     /// value SHOULD be a member of [`PublicKeyCredentialType`] but client platforms MUST ignore any
@@ -93,7 +94,7 @@ impl PublicKeyCredentialDescriptor {
 /// [user verification]: https://w3c.github.io/webauthn/#user-verification
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-#[typeshare(serialized_as = "String")]
+#[cfg_attr(feature = "typeshare", typeshare(serialized_as = "String"))]
 pub enum UserVerificationRequirement {
     /// The Relying Party requires user verification for the operation and will fail the overall
     /// ceremony if the response does not have the UV flag set. The client MUST return an error if
@@ -119,7 +120,7 @@ pub enum UserVerificationRequirement {
 /// <https://w3c.github.io/webauthn/#enum-transport>
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-#[typeshare(serialized_as = "String")]
+#[cfg_attr(feature = "typeshare", typeshare(serialized_as = "String"))]
 pub enum AuthenticatorTransport {
     /// Indicates the respective authenticator can be contacted over removable USB.
     Usb,
@@ -150,7 +151,7 @@ pub enum AuthenticatorTransport {
 /// <https://w3c.github.io/webauthn/#enumdef-authenticatorattachment>
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-#[typeshare(serialized_as = "String")]
+#[cfg_attr(feature = "typeshare", typeshare(serialized_as = "String"))]
 pub enum AuthenticatorAttachment {
     /// This value indicates platform attachment which is attached using a client device-specific
     /// transport, called **platform attachment**, and is usually not removable from the client
@@ -182,7 +183,7 @@ pub enum AuthenticatorAttachment {
 /// <https://w3c.github.io/webauthn/#enum-hints>
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-#[typeshare(serialized_as = "String")]
+#[cfg_attr(feature = "typeshare", typeshare(serialized_as = "String"))]
 #[non_exhaustive]
 pub enum PublicKeyCredentialHints {
     /// Indicates that the Relying Party believes that users will satisfy this request with a physical

--- a/passkey-types/src/webauthn/extensions.rs
+++ b/passkey-types/src/webauthn/extensions.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "typeshare")]
 use typeshare::typeshare;
 
 #[cfg(doc)]
@@ -12,7 +13,7 @@ use crate::webauthn::PublicKeyCredential;
 /// [WebAuthn Extensions]: https://w3c.github.io/webauthn/#webauthn-extensions
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct AuthenticationExtensionsClientInputs {
     /// Boolean to indicate that this extension is requested by the relying party.
     ///
@@ -29,7 +30,7 @@ pub struct AuthenticationExtensionsClientInputs {
 /// [WebAuthn Extensions]: https://w3c.github.io/webauthn/#webauthn-extensions
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct AuthenticatorExtensionsClientOutputs {
     /// Contains properties of the given [`PublicKeyCredential`] when it is included.
     ///
@@ -47,7 +48,7 @@ pub struct AuthenticatorExtensionsClientOutputs {
 /// [Relying Party]: https://w3c.github.io/webauthn/#relying-party
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[typeshare]
+#[cfg_attr(feature = "typeshare", typeshare)]
 pub struct CredentialPropertiesOutput {
     /// This OPTIONAL property, known abstractly as the resident key credential property
     /// (i.e., client-side [discoverable credential] property), is a Boolean value indicating whether


### PR DESCRIPTION
Make the typeshare dependency optional since it's generally not required. Due to some rust limitations I had to duplicate two struct fields.